### PR TITLE
feat: Add FreeScout chat widget integration to enhance user support

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
     <link rel="manifest" href="site.webmanifest">
+    <!-- FreeScout BEGIN -->
+    <script>var FreeScoutW={s:{"color":"#e49515","position":"br","locale":"en","require":["name","email"],"id":768469293}};(function(d,e,s){if(d.getElementById("freescout-w"))return;a=d.createElement(e);m=d.getElementsByTagName(e)[0];a.async=1;a.id="freescout-w";a.src=s;m.parentNode.insertBefore(a, m)})(document,"script","https://support.oakworks.io/modules/chat/js/widget.js?v=9214");</script>
+    <!-- FreeScout END -->
     <style type="text/css">
         .b-divider {
             width: 100%;
@@ -750,7 +753,7 @@
     </footer>
 
     <!-- Cookie consent overlay -->
-    <div id="cookie-consent" class="alert alert-info fixed-bottom mb-0" style="display: none; z-index: 9999;">
+    <div id="cookie-consent" class="alert alert-info fixed-bottom mb-0" style="display: none; z-index: 2;">
         <div class="container d-flex justify-content-between align-items-center">
             <span>This website uses cookies to ensure you get the best experience on our website. <a href="privacy_policy.html">Learn more</a></span>
             <button id="accept-cookies" class="btn btn-primary">Got it!</button>


### PR DESCRIPTION
This pull request introduces a FreeScout chat widget to the website and adjusts the z-index of the cookie consent overlay for better layering. Below are the key changes:

### Integration of FreeScout Chat Widget:
* Added a FreeScout chat widget script to the `index.html` file, enabling a customer support chat feature on the website. The widget is configured with specific settings such as color, position, locale, and required fields. (`[index.htmlR51-R53](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R51-R53)`)

### UI Layering Adjustment:
* Updated the z-index of the cookie consent overlay in `index.html` from `9999` to `2` to resolve potential layering conflicts with other UI elements. (`[index.htmlL753-R756](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L753-R756)`)